### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@
 . Tầm nhìn bị hạn chế đến 1 km ở một số khu vực.
 . Sự bất bình lan tỏa trên mạng xã hội và trên truyền hình với các hashtag liên quan đến ô nhiễm và các khách mời trên truyền hình đưa ra lời khuyên đến công chúng về loại mặt nạ nào người dân nên mang.
 . Air Visual, tổ chức giám sát chất lượng không khí online độc lập (AQI) đánh giá Bangkok ở mức "không tốt cho sức khỏe" với trị số 156 AQI đo ngày hôm qua, dù số liệu còn cao hơn từ hai tháng trước.
-. Nhưng ủy ban ô nhiễm dùng máy đo PM2.5 và đo được trị số ô nhiễm cao nhất là 102 miligram bụi trên 1 mét vuông (Ông Pralong nói: ở mức 120-150 người ta mới phải đeo mặt nạ)
+. Nhưng ủy ban ô nhiễm dùng máy đo PM2.5 và đo được trị số ô nhiễm cao nhất là 102 miligram bụi trên 1 mét vuông (Ông Pralong nói: ở mức 120-150 người ta mới phải đeo mặt nạ
 
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# hello-world
-just another respository
+# Thailand làm mưa nhân tạo vì bụi ô nhiễm bao phủ thành phố.
+. Thailand đang triển khai làm mưa nhân tạo để nỗ lực giải quyết màn bụi ô nhiễm bao phủ thủ đô Bangkok trong những tuần gần đây.
+. Biện pháp kỹ thuật trong lý thuyết làm mưa nhân tạo là phun chất hóa học vào không khí để hỗ trợ quá trình làm mây dày đặc.
+. Hội đồng tạo mưa nhân tạo hy vọng quá trình tạo mưa sẽ hoàn thành trong ngày hôm nay nhưng nó còn phụ thuộc vào mức độ gió và độ ẩm.
+. Bangkok giờ đây là một trong mười thành phố ô nhiễm nhất thế giới, cùng với một số thành phố khác của Trung Quốc.
+. Lý do phát sinh bụi ô nhiễm kéo dài là do khói bụi từ phương tiện giao thông, đốt rơm rạ trên các cánh đồng ven thành phố và khói từ các nhà máy.
+. Tầm nhìn bị hạn chế đến 1 km ở một số khu vực.
+. Sự bất bình lan tỏa trên mạng xã hội và trên truyền hình với các hashtag liên quan đến ô nhiễm và các khách mời trên truyền hình đưa ra lời khuyên đến công chúng về loại mặt nạ nào người dân nên mang.
+. Air Visual, tổ chức giám sát chất lượng không khí online độc lập (AQI) đánh giá Bangkok ở mức "không tốt cho sức khỏe" với trị số 156 AQI đo ngày hôm qua, dù số liệu còn cao hơn từ hai tháng trước.
+. Nhưng ủy ban ô nhiễm dùng máy đo PM2.5 và đo được trị số ô nhiễm cao nhất là 102 miligram bụi trên 1 mét vuông (Ông Pralong nói: ở mức 120-150 người ta mới phải đeo mặt nạ)
+
+


### PR DESCRIPTION
. Thailand đang triển khai làm mưa nhân tạo để nỗ lực giải quyết màn bụi ô nhiễm bao phủ thủ đô Bangkok trong những tuần gần đây.
. Biện pháp kỹ thuật trong lý thuyết làm mưa nhân tạo là phun chất hóa học vào không khí để hỗ trợ quá trình làm mây dày đặc.
. Hội đồng tạo mưa nhân tạo hy vọng quá trình tạo mưa sẽ hoàn thành trong ngày hôm nay nhưng nó còn phụ thuộc vào mức độ gió và độ ẩm.
. Bangkok giờ đây là một trong mười thành phố ô nhiễm nhất thế giới, cùng với một số thành phố khác của Trung Quốc.
. Lý do phát sinh bụi ô nhiễm kéo dài là do khói bụi từ phương tiện giao thông, đốt rơm rạ trên các cánh đồng ven thành phố và khói từ các nhà máy.
. Tầm nhìn bị hạn chế đến 1 km ở một số khu vực.
. Sự bất bình lan tỏa trên mạng xã hội và trên truyền hình với các hashtag liên quan đến ô nhiễm và các khách mời trên truyền hình đưa ra lời khuyên đến công chúng về loại mặt nạ nào người dân nên mang.
. Air Visual, tổ chức giám sát chất lượng không khí online độc lập (AQI) đánh giá Bangkok ở mức "không tốt cho sức khỏe" với trị số 156 AQI đo ngày hôm qua, dù số liệu còn cao hơn từ hai tháng trước.
. Nhưng ủy ban ô nhiễm dùng máy đo PM2.5 và đo được trị số ô nhiễm cao nhất là 102 miligram bụi trên 1 mét vuông (Ông Pralong nói: ở mức 120-150 người ta mới phải đeo mặt nạ)

